### PR TITLE
Add release packaging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: build-and-release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install .
+      - name: Build executable
+        run: pyinstaller dedupe_ui.py --name dedupe-ui --onefile
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dedupe-ui-${{ matrix.os }}
+          path: dist/dedupe-ui*
+
+  release:
+    name: Create release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Extract version
+        run: echo "VERSION=$(grep -Po '(?<=^version = \")[^\"]*' pyproject.toml)" >> $GITHUB_ENV
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: v${{ env.VERSION }}
+          files: dist/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Package the application with PyInstaller on Windows, macOS, and Linux
- Publish built artifacts as a GitHub release when changes land on `main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c86f4104832d9f908db7e7d3dd93