### PR TITLE
chore: fix release asset naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: linux
+            ext: ""
+          - os: macos-latest
+            artifact_name: macos
+            ext: ""
+          - os: windows-latest
+            artifact_name: windows
+            ext: ".exe"
 
     steps:
       - uses: actions/checkout@v4
@@ -27,12 +36,12 @@ jobs:
           pip install pyinstaller
           pip install .
       - name: Build executable
-        run: pyinstaller dedupe_ui.py --name dedupe-ui --onefile
+        run: pyinstaller dedupe_ui.py --name dedupe-ui-${{ matrix.artifact_name }} --onefile
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dedupe-ui-${{ matrix.os }}
-          path: dist/dedupe-ui*
+          name: dedupe-ui-${{ matrix.artifact_name }}
+          path: dist/dedupe-ui-${{ matrix.artifact_name }}${{ matrix.ext }}
 
   release:
     name: Create release
@@ -55,5 +64,6 @@ jobs:
           tag_name: v${{ env.VERSION }}
           name: v${{ env.VERSION }}
           files: dist/**
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- make build matrix give each OS its own artifact name
- add release notes and upload the artifacts with OS-specific names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4cd3bea80832dac6ea2af6d0eaeed