### PR TITLE
Add pause/stop controls, drag-and-drop paths, and debug logging

### DIFF
--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -4,6 +4,9 @@ from pathlib import Path
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtCore import QMimeData, Qt, QPointF, QUrl
+from PySide6.QtGui import QDropEvent
+from PySide6.QtTest import QTest
 
 # Ensure a single QApplication instance
 app = QApplication.instance() or QApplication([])
@@ -73,3 +76,66 @@ def test_deletion_progress(tmp_path, monkeypatch):
     assert not p.exists()
     assert win.progress_bar.value() == 100
     assert "Deletion complete" in win.status_label.text()
+
+
+def test_drag_and_drop_folder_selection(tmp_path):
+    win = App()
+    a = tmp_path / "A"
+    b = tmp_path / "B"
+    a.mkdir()
+    b.mkdir()
+
+    mime = QMimeData()
+    mime.setUrls([QUrl.fromLocalFile(str(a))])
+    event = QDropEvent(QPointF(), Qt.CopyAction, mime, Qt.LeftButton, Qt.NoModifier)
+    win.entry_a.dragEnterEvent(event)
+    win.entry_a.dropEvent(event)
+    assert win.entry_a.text() == str(a)
+
+    mime2 = QMimeData()
+    mime2.setUrls([QUrl.fromLocalFile(str(b))])
+    event2 = QDropEvent(QPointF(), Qt.CopyAction, mime2, Qt.LeftButton, Qt.NoModifier)
+    win.entry_b.dragEnterEvent(event2)
+    win.entry_b.dropEvent(event2)
+    assert win.entry_b.text() == str(b)
+
+
+def test_pause_and_log_panel(tmp_path, monkeypatch):
+    import stage1
+    orig_iter = stage1.iter_files
+
+    def slow_iter(path):
+        for p in orig_iter(path):
+            import time
+            time.sleep(0.01)
+            yield p
+
+    monkeypatch.setattr(stage1, "iter_files", slow_iter)
+
+    win = App()
+    a = tmp_path / "A"
+    b = tmp_path / "B"
+    a.mkdir()
+    b.mkdir()
+    for i in range(5):
+        (a / f"f{i}.txt").write_text("x")
+        (b / f"f{i}.txt").write_text("x")
+
+    win.entry_a.setText(str(a))
+    win.entry_b.setText(str(b))
+    win.log_box.setChecked(True)
+    win.start_stage1()
+    win.toggle_pause()
+    QTest.qWait(50)
+    assert win.btn_pause.text() == "Resume"
+    assert win.log_view.toPlainText() == ""
+    win.toggle_pause()
+    for _ in range(20):
+        if win.log_view.toPlainText():
+            break
+        QTest.qWait(50)
+    assert win.log_view.toPlainText() != ""
+    win.stop_current()
+    win.stage1_thread.wait()
+    win.log_box.setChecked(False)
+    assert not win.log_view.isVisible()


### PR DESCRIPTION
## Summary
- add stoppable and pausable scanning/verifying with per-file logging
- support drag-and-drop folder selection in the UI
- include collapsible debug log panel and automated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d5a0e994832da8e27e4b30bc4acc