### PR TITLE
Add send2trash dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "platformdirs",
     "PySide6",
+    "send2trash",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- include `send2trash` in project dependencies so Windows builds have the module available

## Testing
- `pytest -q` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c559b3f074832d8161d693f7ea7ac4